### PR TITLE
Update to base-4.16.4.0

### DIFF
--- a/base-noprelude.cabal
+++ b/base-noprelude.cabal
@@ -35,11 +35,12 @@ source-repository head
     location: https://github.com/hvr/base-noprelude.git
 
 library
-    build-depends:       base ==4.16.1.0
+    build-depends:       base ==4.16.4.0
     default-language:    Haskell2010
 
     -- re-exported modules copied from exposed-modules / reexported-modules of
-    -- https://hackage.haskell.org/package/base-4.16.1.0/base.cabal
+    -- https://hackage.haskell.org/package/base-4.16.4.0/base.cabal
+
     reexported-modules:
       , Control.Applicative
       , Control.Arrow


### PR DESCRIPTION
For context, this is for [morley#919](https://gitlab.com/morley-framework/morley/-/issues/919): stackage LTS 20.4 uses base 4.16.4.0 (as this is what's bundled with GHC-9.2.5). Naturally, we want to have the same here, but without `Prelude`.